### PR TITLE
Fix install instruction for 'go install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```
-$ go install github.com/orlangure/gocovsh
+$ go install github.com/orlangure/gocovsh@latest
 ```
 
 More installation options will follow.


### PR DESCRIPTION
This requires a version tag to install, otherwise you'll see an error:

```
go install: version is required when current directory is not in a module
```