### PR TITLE
feat: goreleaser setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+#
+# Releaser workflow setup
+# https://goreleaser.com/ci/actions/
+#
+name: release
+
+# run only on tags
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+   contents: write # needed to write releases
+   id-token: write # needed for keyless signing
+   packages: write # needed for ghcr access
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: sigstore/cosign-installer@v2.0.0         # installs cosign
+      - uses: goreleaser/goreleaser-action@v2          # run goreleaser
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          BREW_GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          BREW_GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,4 @@ jobs:
           args: release --rm-dist
         env:
           BREW_GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  use: github
+brews:
+  - tap:
+      owner: orlangure
+      name: homebrew-tap
+      token: "{{ .Env.BREW_GITHUB_TOKEN }}"
+    folder: Formula
+    homepage: https://github.com/orlangure/gocovsh
+    description: 'Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line'
+nfpms:
+  - homepage: https://github.com/orlangure/gocovsh
+    description: 'Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line'
+    maintainer: Yury Fedorov
+    license: GPL-3.0-only
+    vendor: Yury Fedorov
+    formats:
+    - apk
+    - deb
+    - rpm
+signs:
+  - cmd: cosign
+    env:
+    - COSIGN_EXPERIMENTAL=1
+    certificate: '${artifact}.pem'
+    output: true
+    artifacts: checksum
+    args:
+    - sign-blob
+    - '--output-certificate=${certificate}'
+    - '--output-signature=${signature}'
+    - '${artifact}'


### PR DESCRIPTION
closes #9 
closes #8 

#### This adds:

- build the binaries for windows, linux and darwin, amd64, arm64 and 386 (can add more if you want/need)
- keyless sign archives with cosign
- create a release on github and upload the artifacts
- create/update the formula on a homebrew-tap repository

#### TODOs for @orlangure

- create a `homebrew-tap` repository
- create a personal access token with write access
- add it as a secret to this project (named `GITHUB_PAT`)
- cut a new tag 