### PR TITLE
Support 3 states of help: hidden, visible, full

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   enable:
     - bodyclose
-    # - cyclop
     - deadcode
     - depguard
     - dogsled
@@ -13,9 +12,7 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    # - gocyclo
     - godot
-    # - godox
     - gofmt
     - gofumpt
     - goimports

--- a/main.go
+++ b/main.go
@@ -13,6 +13,13 @@ const (
 )
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	var profileFilename string
 
 	flag.StringVar(
@@ -23,11 +30,22 @@ func main() {
 
 	m := model{
 		activeView:      activeViewList,
+		helpState:       helpStateShort,
 		profileFilename: profileFilename,
 	}
 
-	if err := tea.NewProgram(m, tea.WithAltScreen()).Start(); err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+	if os.Getenv("DEBUG") != "" {
+		f, err := tea.LogToFile("bubbletea.log", "gocovsh")
+		if err != nil {
+			return fmt.Errorf("failed to setup logger: %w", err)
+		}
+
+		defer func() { _ = f.Close() }()
 	}
+
+	if err := tea.NewProgram(m, tea.WithAltScreen()).Start(); err != nil {
+		return fmt.Errorf("failed to start program: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/codeview/keys.go
+++ b/pkg/codeview/keys.go
@@ -4,12 +4,14 @@ import "github.com/charmbracelet/bubbles/key"
 
 // KeyMap includes codeview key mappings.
 type KeyMap struct {
-	Up   key.Binding
-	Down key.Binding
-	Home key.Binding
-	End  key.Binding
-	Back key.Binding
-	Quit key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	Home           key.Binding
+	End            key.Binding
+	Back           key.Binding
+	Quit           key.Binding
+	HalfScreenDown key.Binding
+	HalfScreenUp   key.Binding
 }
 
 // DefaultKeyMap is the default KeyMap used by codeview package.
@@ -37,5 +39,13 @@ var DefaultKeyMap = KeyMap{
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),
 		key.WithHelp("q", "quit"),
+	),
+	HalfScreenDown: key.NewBinding(
+		key.WithKeys("d"),
+		key.WithHelp("d", "half screen down"),
+	),
+	HalfScreenUp: key.NewBinding(
+		key.WithKeys("u"),
+		key.WithHelp("u", "half screen down"),
 	),
 }


### PR DESCRIPTION
After a couple usages the keys should be memorized, so the users might
want to hide the help completely to add another row to the code
view/list.

In the future, help section state will be persisted in the optional
configuration file, so that for every new gocovsh session the menu will
be in the selected state.

Closes #3 