### PR TITLE
feat: use go mod proxying

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath
+gomod:
+  proxy: true
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/internal/program/options.go
+++ b/internal/program/options.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"io"
 	"io/fs"
+	"runtime/debug"
 )
 
 // Option is a function that can be passed to WithOptions.
@@ -15,6 +16,16 @@ func WithBuildInfo(version, commit, date string) Option {
 		p.version = version
 		p.commit = commit
 		p.date = date
+	}
+}
+
+// WithGoModInfo reads build info and sets its fields, if its available.
+func WithGoModInfo() Option {
+	return func(p *Program) {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
+			p.modVersion = info.Main.Version
+			p.modSum = info.Main.Sum
+		}
 	}
 }
 

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -65,6 +65,9 @@ type Program struct {
 	commit  string
 	date    string
 
+	modVersion string
+	modSum     string
+
 	showVersion     bool
 	profileFilename string
 	sortByCoverage  bool
@@ -89,6 +92,13 @@ func (p *Program) Run() error {
 			"Version: %s\nCommit: %s\nDate: %s\n",
 			p.version, p.commit, p.date,
 		)
+		if p.modVersion != "" && err != nil {
+			_, err = fmt.Fprintf(
+				p.output,
+				"Module Version: %s\nModule Checksum: %s\n",
+				p.modVersion, p.modSum,
+			)
+		}
 
 		return err
 	}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -87,19 +87,18 @@ func (p *Program) Run() error {
 	}
 
 	if p.showVersion {
-		_, err := fmt.Fprintf(
-			p.output,
+		out := fmt.Sprintf(
 			"Version: %s\nCommit: %s\nDate: %s\n",
 			p.version, p.commit, p.date,
 		)
-		if p.modVersion != "" && err != nil {
-			_, err = fmt.Fprintf(
-				p.output,
+		if p.modVersion != "" {
+			out += fmt.Sprintf(
 				"Module Version: %s\nModule Checksum: %s\n",
 				p.modVersion, p.modSum,
 			)
 		}
 
+		_, err := fmt.Fprint(p.output, out)
 		return err
 	}
 

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -99,6 +99,7 @@ func (p *Program) Run() error {
 		}
 
 		_, err := fmt.Fprint(p.output, out)
+
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,13 +9,14 @@ import (
 
 var (
 	// build information, set by goreleaser.
-	version string
+	version = "dev"
 	commit  string
 	date    string
 )
 
 func main() {
 	if err := program.New(
+		program.WithGoModInfo(),
 		program.WithBuildInfo(version, commit, date),
 		program.WithLogFile(os.Getenv("GOCOVSH_LOG_FILE")),
 	).Run(); err != nil {


### PR DESCRIPTION
This enables read build info both on binaries built by goreleaser, as
well as installed with `go install` directly.

More info: https://carlosbecker.com/posts/supply-chain-goreleaser-go-mod-proxy/
