### PR TITLE
Fix requested files parsing

### DIFF
--- a/internal/gocovshtest/input/input.go
+++ b/internal/gocovshtest/input/input.go
@@ -1,0 +1,39 @@
+package input
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"os"
+)
+
+func NewMockFile(data string, mode fs.FileMode) *MockFile {
+	return &MockFile{
+		Reader: bytes.NewBufferString(data),
+		Size:   int64(len(data)),
+		Mode:   mode,
+	}
+}
+
+type MockFile struct {
+	Reader    io.Reader
+	Mode      fs.FileMode
+	Size      int64
+	InputRead bool
+}
+
+func (m *MockFile) Stat() (fs.FileInfo, error) { return &mockFileInfo{size: m.Size, mode: m.Mode}, nil }
+func (m *MockFile) Close() error               { return nil }
+func (m *MockFile) Read(buf []byte) (int, error) {
+	m.InputRead = true
+	return m.Reader.Read(buf)
+}
+
+type mockFileInfo struct {
+	fs.FileInfo
+	size int64
+	mode fs.FileMode
+}
+
+func (fi *mockFileInfo) Mode() os.FileMode { return fi.mode }
+func (fi *mockFileInfo) Size() int64       { return fi.size }

--- a/internal/program/program_internal_test.go
+++ b/internal/program/program_internal_test.go
@@ -1,0 +1,65 @@
+package program
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/orlangure/gocovsh/internal/gocovshtest/input"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	filesList = `
+foo.go
+bar.go
+baz.go
+`
+
+	diffStr = `
+diff --git a/main.go b/main.go
+index e6cd709..adc400e 100644
+--- a/main.go
++++ b/main.go
+@@ -2,6 +2,7 @@ package main
+ 
+ import (
+ 	"fmt"
++	_ "foo"
+ 	"os"
+ 
+ 	"github.com/orlangure/gocovsh/internal/program"
+`
+)
+
+func TestParseInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("files list", func(t *testing.T) {
+		flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+		f := input.NewMockFile(filesList, os.ModeNamedPipe)
+		p := New(
+			WithInput(f),
+			WithFlagSet(flagSet, nil),
+		)
+
+		err := p.parseInput()
+		require.NoError(t, err)
+		require.Len(t, p.requestedFiles, 3)
+		require.EqualValues(t, []string{"foo.go", "bar.go", "baz.go"}, p.requestedFiles)
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+		f := input.NewMockFile(diffStr, os.ModeNamedPipe)
+		p := New(
+			WithInput(f),
+			WithFlagSet(flagSet, nil),
+		)
+
+		err := p.parseInput()
+		require.NoError(t, err)
+		require.Len(t, p.requestedFiles, 1)
+		require.EqualValues(t, []string{"main.go"}, p.requestedFiles)
+	})
+}

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
-	"io/fs"
 	"os"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/orlangure/gocovsh/internal/gocovshtest/input"
 	"github.com/orlangure/gocovsh/internal/program"
 	"github.com/stretchr/testify/require"
 )
@@ -68,56 +67,25 @@ func TestLogger(t *testing.T) {
 func TestInput(t *testing.T) {
 	t.Run("read input with pipe mode", func(t *testing.T) {
 		flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
-		f := newMockFile("foo\nbar\r\nbaz\n", os.ModeNamedPipe)
+		f := input.NewMockFile("foo\nbar\r\nbaz\n", os.ModeNamedPipe)
 		p := program.New(
 			program.WithInput(f),
 			program.WithFlagSet(flagSet, nil),
 		)
 
 		require.Error(t, p.Run())
-		require.True(t, f.inputRead)
+		require.True(t, f.InputRead)
 	})
 
 	t.Run("ignore input with other mode", func(t *testing.T) {
 		flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
-		f := newMockFile("foo\nbar\r\nbaz\n", os.ModeDir)
+		f := input.NewMockFile("foo\nbar\r\nbaz\n", os.ModeDir)
 		p := program.New(
 			program.WithInput(f),
 			program.WithFlagSet(flagSet, nil),
 		)
 
 		require.Error(t, p.Run())
-		require.False(t, f.inputRead)
+		require.False(t, f.InputRead)
 	})
 }
-
-func newMockFile(data string, mode fs.FileMode) *mockFile {
-	return &mockFile{
-		reader: bytes.NewBufferString(data),
-		size:   int64(len(data)),
-		mode:   mode,
-	}
-}
-
-type mockFile struct {
-	reader    io.Reader
-	mode      fs.FileMode
-	size      int64
-	inputRead bool
-}
-
-func (m *mockFile) Stat() (fs.FileInfo, error) { return &mockFileInfo{size: m.size, mode: m.mode}, nil }
-func (m *mockFile) Close() error               { return nil }
-func (m *mockFile) Read(buf []byte) (int, error) {
-	m.inputRead = true
-	return m.reader.Read(buf)
-}
-
-type mockFileInfo struct {
-	fs.FileInfo
-	size int64
-	mode fs.FileMode
-}
-
-func (fi *mockFileInfo) Mode() os.FileMode { return fi.mode }
-func (fi *mockFileInfo) Size() int64       { return fi.size }


### PR DESCRIPTION
Adding `git diff` parser broke `git diff --name-only` flow... This
commit allows to use both, depending on the input.