### PR TITLE
Issue #22: Initial solution for toggling sorting profiles by percentage

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -78,6 +78,8 @@ type Model struct {
 	detectedPackageName string
 	requestedFiles      map[string]bool
 	filteredLinesByFile map[string][]int
+    profilesLoaded      []*cover.Profile
+    sortByAsc           bool
 
 	activeView viewName
 	helpState  helpState
@@ -188,7 +190,12 @@ func (m *Model) onProfilesLoaded(profiles []*cover.Profile) (tea.Model, tea.Cmd)
 
 	if m.sortByCoverage {
 		sort.Slice(profiles, func(i, j int) bool {
-			return percentCovered(profiles[i]) < percentCovered(profiles[j])
+            if m.sortByAsc {
+                return percentCovered(profiles[i]) > percentCovered(profiles[j])
+            } else {
+                return percentCovered(profiles[i]) < percentCovered(profiles[j]) 
+            }
+
 		})
 	}
 
@@ -254,7 +261,20 @@ func (m *Model) onKeyPressed(key string) (tea.Model, tea.Cmd) {
 			return m, loadFile(adjustedFileName, item.profile)
 		}
 
-		return m, nil
+        return m, nil
+
+    //toggle on and inisiate sortByCoverage (default = Asc)
+    case "[":
+        m.sortByCoverage = true
+        m.sortByAsc = !m.sortByAsc
+        m.Update(m.profilesLoaded)
+        return m, nil
+
+    case "]":
+        m.sortByCoverage = false
+        m.sortByAsc = false
+        m.Update(m.profilesLoaded)
+        return m, nil
 
 	case "?":
 		m.toggleHelp()
@@ -328,6 +348,7 @@ func (m *Model) loadProfiles(codeRoot, profileFilename string) tea.Cmd {
 
 			finalProfiles = append(finalProfiles, p)
 		}
+        m.profilesLoaded = finalProfiles
 
 		return finalProfiles
 	}


### PR DESCRIPTION
Picked two arbitrary keybinds "[" toggles on sortedByPercentage and will toggle back and forth between Asc and Desc order. "]" turns off sorting by percentage. Need to add "instructions" to the key map. i.e. "[ toggle sort by percentage"

Please give feedback on possible better solutions or best practices. 

NOT YET COMPLETED: 
![Screen Shot 2023-02-25 at 7 59 58 PM](https://user-images.githubusercontent.com/92348198/221391595-abd6c466-b9c6-4e79-ac60-1118a2465253.png)

I need to still implement adding the key bindings to the "register" of key maps. I could use some tips on this.

Thanks!